### PR TITLE
Issue 16: widen columns for Data Processing tabs

### DIFF
--- a/src/pages/Reporting/DataProcessing/GeneratedSdsProducts/index.jsx
+++ b/src/pages/Reporting/DataProcessing/GeneratedSdsProducts/index.jsx
@@ -14,7 +14,7 @@ function GeneratedSdsProducts(props) {
       field: "id",
       headerName: "OPERA Product Short Name",
       flex: 0,
-      minWidth: 150,
+      minWidth: 200,
     },
     {
       field: "files_produced",

--- a/src/pages/Reporting/DataProcessing/IncomingSdpProducts/index.jsx
+++ b/src/pages/Reporting/DataProcessing/IncomingSdpProducts/index.jsx
@@ -14,7 +14,7 @@ function IncomingSdpProducts(props) {
       field: "id",
       headerName: "Input Product Short Name",
       flex: 0,
-      minWidth: 150,
+      minWidth: 200,
     },
     {
       field: "num_ingested",


### PR DESCRIPTION
### Description

In this pull request, the minWidth property in the columns of the GeneratedSdsProducts and IncomingSdpProducts tables in the DataProcessing section of the Reporting page is being updated from 150 to 200.

Changes:
- Modified minWidth property in the column definition for "OPERA Product Short Name" in GeneratedSdsProducts table from 150 to 200.
- Modified minWidth property in the column definition for "Input Product Short Name" in IncomingSdpProducts table from 150 to 200.

<!-- Korbit AI PR Description Start -->
## Description by Korbit AI

### What change is being made?

Increase the minimum width of the &quot;OPERA Product Short Name&quot; and &quot;Input Product Short Name&quot; columns from 150 to 200 in the Data Processing tabs.

### Why are these changes being made?

The columns were too narrow to display the full product names, leading to truncated text and a poor user experience. Widening the columns ensures that the full names are visible, improving readability and usability of the data processing interface.

<!-- Korbit AI PR Description End -->